### PR TITLE
Use the HTTPS endpoint

### DIFF
--- a/represent/__init__.py
+++ b/represent/__init__.py
@@ -10,7 +10,7 @@ from time import sleep
 
 import requests
 
-BASE_URL = 'http://represent.opennorth.ca'
+BASE_URL = 'https://represent.opennorth.ca'
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
To avoid transmitting personal information like lat/lng and postal code as cleartext
